### PR TITLE
Fix bug with unchangeable font family

### DIFF
--- a/styles/blocks/_typography.scss
+++ b/styles/blocks/_typography.scss
@@ -1,31 +1,34 @@
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/light/opensans-300',
-    $font-weight: 300,
-    $font-style: normal
-);
+@if $font-family-name__base == 'Open Sans' {
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/regular/opensans-400',
-    $font-weight: 400,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/light/opensans-300',
+        $font-weight: 300,
+        $font-style: normal
+    );
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/semibold/opensans-600',
-    $font-weight: 600,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/regular/opensans-400',
+        $font-weight: 400,
+        $font-style: normal
+    );
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/bold/opensans-700',
-    $font-weight: 700,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/semibold/opensans-600',
+        $font-weight: 600,
+        $font-style: normal
+    );
 
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/bold/opensans-700',
+        $font-weight: 700,
+        $font-style: normal
+    );
+
+}
 //
 //  Desktop
 //  _____________________________________________


### PR DESCRIPTION
If you change the base font family using `$font-family-name__base` all typo will still displayed in Open Sans, because this variable is also used to include the Open Sans font files.